### PR TITLE
Update pack format to 1.18

### DIFF
--- a/src/main/resources/resourcepacks/smartleaves/pack.mcmeta
+++ b/src/main/resources/resourcepacks/smartleaves/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 7,
+    "pack_format": 8,
     "description": "§2Makes leaves look identical to optifine's smart leaves"
   }
 }


### PR DESCRIPTION
This is required for modpacks that want to have the resourcepack enabled on start (Minecraft disables "incompatible" resourcepacks).

Fixes https://github.com/TeamMidnightDust/CullLeaves/issues/19